### PR TITLE
Fix Service Fabric templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Package code owners
+
+# The listed owners will be automatically added as reviewers for PRs,
+# to ensure code quality and consistency of the package, and identify
+# possible side effects.
+# PRs should still be peer-reviewed by the team opening the PR
+
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another the rest of the directory.
+
+*                  @DataDog/agent-platform
+README.md          @DataDog/documentation
+CONTRIBUTING.md    @DataDog/documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What does this PR do?
+
+<!-- A brief description of the change being made with this pull request. -->
+
+### Motivation
+
+<!-- What inspired you to submit this pull request? -->
+
+### Additional Notes
+
+<!-- Anything else we should know when reviewing? -->
+
+### Describe your test plan
+
+<!-- Write there any instructions and details you may have to test your PR. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@
 
 ### Local testing
 
-To test the template without actually deploying it there are two basic tools that you can use
+To test the template without actually deploying, use one of these tools:
 
-1. The [Azure Resource Manager Template Toolkit](https://github.com/Azure/arm-ttk) provides a series of scripts for enforcing best practices when writing templates.
+- The [Azure Resource Manager Template Toolkit](https://github.com/Azure/arm-ttk) provides a series of scripts for enforcing best practices when writing templates.
    These are best practices and we do not follow all of them. In particular, currently we do not follow the rules for API versions and `concat` usage.
-   It is recommended that you compare the output of the script for the template you are modifying before and after your changes to check that you do not introduce any new issues.
-2. You can run some checks if you follow the Usage instructions but append the `-WhatIf` command to do a dry run.
+   Datadog recommends that you compare the output of the script for the template you are modifying before and after your changes to check that you do not introduce any new issues.
+- You can run some checks if you follow the usage instructions but append the `-WhatIf` command to do a dry run.
 
 ### Testing deployment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Template development and testing
+
+### Local testing
+
+To test the template without actually deploying it there are two basic tools that you can use
+
+1. The [Azure Resource Manager Template Toolkit](https://github.com/Azure/arm-ttk) provides a series of scripts for enforcing best practices when writing templates.
+   These are best practices and we do not follow all of them. In particular, currently we do not follow the rules for API versions and `concat` usage.
+   It is recommended that you compare the output of the script for the template you are modifying before and after your changes to check that you do not introduce any new issues.
+2. You can run some checks if you follow the Usage instructions but append the `-WhatIf` command to do a dry run.
+
+### Testing deployment
+
+You can deploy the template following the usage instructions on the README.
+After deployment, it can  be useful to log into a node to debug it.
+
+To do that you need to connect via the load balancer, which is assigned a public IP and handles automatically the assignment of a port for each node.
+You can find the IP-port combination to log into a specific node by looking at the "inbound NAT rules" on the Azure portal.

--- a/Linux/parameters.json
+++ b/Linux/parameters.json
@@ -11,12 +11,6 @@
         "computeLocation": {
             "value": "eastus"
         },
-        "adminUserName": {
-            "value": "adminuser"
-        },
-        "adminPassword": {
-            "value": null
-        },
         "nicName": {
             "value": "NIC-sfdatadoglinux"
         },
@@ -65,8 +59,14 @@
         "nt0reverseProxyEndpointPort": {
             "value": 19081
         },
+        "adminUserName": {
+            "value": "admin"
+        },
+        "adminPassword": {
+            "value": null
+        },
         "datadog_api_key": {
-            "value": ""
+            "value": null
         },
         "datadog_site": {
             "value": "datadoghq.com"

--- a/Linux/parameters.json
+++ b/Linux/parameters.json
@@ -20,17 +20,11 @@
         "nicName": {
             "value": "NIC-sfdatadoglinux"
         },
-        "publicIPAddressName": {
-            "value": "sfdatadoglinux-PubIP"
-        },
         "dnsName": {
             "value": "sfdatadoglinux"
         },
         "virtualNetworkName": {
             "value": "VNet-sfdatadoglinux"
-        },
-        "lbName": {
-            "value": "LB-sfdatadoglinux"
         },
         "lbIPName": {
             "value": "LBIP-sfdatadoglinux"
@@ -73,6 +67,9 @@
         },
         "datadog_api_key": {
             "value": ""
+        },
+        "datadog_site": {
+            "value": "datadoghq.com"
         }
     }
 }

--- a/Linux/template_datadog.json
+++ b/Linux/template_datadog.json
@@ -192,6 +192,9 @@
         },
         "datadog_api_key": {
             "type": "string"
+        },
+        "datadog_site": {
+            "type": "string"
         }
     },
     "variables": {
@@ -524,6 +527,9 @@
                                   "typeHandlerVersion": "0.4",
                                   "autoUpgradeMinorVersion": true,
                                   "settings": {
+                                    "site": "[parameters('datadog_site')]"
+                                  },
+                                  "protectedSettings": {
                                     "api_key": "[parameters('datadog_api_key')]"
                                   }
                                 }

--- a/Linux/template_datadog.json
+++ b/Linux/template_datadog.json
@@ -524,7 +524,7 @@
                                 "properties": {
                                   "publisher": "Datadog.Agent",
                                   "type": "DatadogLinuxAgent",
-                                  "typeHandlerVersion": "0.4",
+                                  "typeHandlerVersion": "1.0",
                                   "autoUpgradeMinorVersion": true,
                                   "settings": {
                                     "site": "[parameters('datadog_site')]"

--- a/Linux/template_datadog.json
+++ b/Linux/template_datadog.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "clusterLocation": {
@@ -54,21 +54,6 @@
         "computeLocation": {
             "type": "string"
         },
-        "publicIPAddressName": {
-            "type": "string",
-            "defaultValue": "PublicIP-VM"
-        },
-        "publicIPAddressType": {
-            "type": "string",
-            "allowedValues": [
-                "Dynamic"
-            ],
-            "defaultValue": "Dynamic"
-        },
-        "vmStorageAccountContainerName": {
-            "type": "string",
-            "defaultValue": "vhds"
-        },
         "adminUserName": {
             "type": "string",
             "defaultValue": "testadm",
@@ -96,10 +81,6 @@
         "nicName": {
             "type": "string",
             "defaultValue": "NIC"
-        },
-        "lbName": {
-            "type": "string",
-            "defaultValue": "LoadBalancer"
         },
         "lbIPName": {
             "type": "string",
@@ -232,7 +213,6 @@
         "lbProbeID0": "[concat(variables('lbID0'),'/probes/FabricGatewayProbe')]",
         "lbHttpProbeID0": "[concat(variables('lbID0'),'/probes/FabricHttpGatewayProbe')]",
         "lbNatPoolID0": "[concat(variables('lbID0'),'/inboundNatPools/LoadBalancerBEAddressNatPool')]",
-        "vmStorageAccountName0": "[toLower(concat(uniqueString(resourceGroup().id), '1', '0' ))]",
         "wadmetricsresourceid0": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',resourceGroup().name ,'/providers/','Microsoft.Compute/virtualMachineScaleSets/', parameters('vmNodeType0Name'))]"
     },
     "resources": [
@@ -241,7 +221,6 @@
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('supportLogStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {},
             "kind": "Storage",
             "sku": {
@@ -257,7 +236,6 @@
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('applicationDiagnosticsStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {},
             "kind": "Storage",
             "sku": {
@@ -273,7 +251,6 @@
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtualNetworkName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -646,8 +623,6 @@
                 "addonFeatures": [
                     "DnsService"
                 ],
-                "clientCertificateCommonNames": [],
-                "clientCertificateThumbprints": [],
                 "clusterState": "Default",
                 "diagnosticsStorageAccountConfig": {
                     "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",
@@ -656,7 +631,6 @@
                     "storageAccountName": "[parameters('supportLogStorageAccountName')]",
                     "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.table]"
                 },
-                "fabricSettings": [],
                 "managementEndpoint": "[concat('http://',reference(concat(parameters('lbIPName'),'-','0')).dnsSettings.fqdn,':',parameters('nt0fabricHttpGatewayPort'))]",
                 "nodeTypes": [
                     {

--- a/Linux/template_datadog.json
+++ b/Linux/template_datadog.json
@@ -198,11 +198,6 @@
         }
     },
     "variables": {
-        "vmssApiVersion": "2017-03-30",
-        "lbApiVersion": "2015-06-15",
-        "vNetApiVersion": "2015-06-15",
-        "storageApiVersion": "2016-01-01",
-        "publicIPApiVersion": "2015-06-15",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnet0Ref": "[concat(variables('vnetID'),'/subnets/',parameters('subnet0Name'))]",
         "wadlogs": "<WadCfg><DiagnosticMonitorConfiguration>",
@@ -220,7 +215,7 @@
     },
     "resources": [
         {
-            "apiVersion": "[variables('storageApiVersion')]",
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('supportLogStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
@@ -235,7 +230,7 @@
             }
         },
         {
-            "apiVersion": "[variables('storageApiVersion')]",
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('applicationDiagnosticsStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
@@ -250,7 +245,7 @@
             }
         },
         {
-            "apiVersion": "[variables('vNetApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtualNetworkName')]",
             "location": "[parameters('computeLocation')]",
@@ -275,7 +270,7 @@
             }
         },
         {
-            "apiVersion": "[variables('publicIPApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[concat(parameters('lbIPName'),'-','0')]",
             "location": "[parameters('computeLocation')]",
@@ -291,7 +286,7 @@
             }
         },
         {
-            "apiVersion": "[variables('lbApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/loadBalancers",
             "name": "[concat('LB','-', parameters('clusterName'),'-',parameters('vmNodeType0Name'))]",
             "location": "[parameters('computeLocation')]",
@@ -480,7 +475,7 @@
             }
         },
         {
-            "apiVersion": "[variables('vmssApiVersion')]",
+            "apiVersion": "2017-03-30",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "name": "[parameters('vmNodeType0Name')]",
             "location": "[parameters('computeLocation')]",
@@ -631,11 +626,11 @@
                 ],
                 "clusterState": "Default",
                 "diagnosticsStorageAccountConfig": {
-                    "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",
+                    "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), '2016-01-01').primaryEndpoints.blob]",
                     "protectedAccountKeyName": "StorageAccountKey1",
-                    "queueEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.queue]",
+                    "queueEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), '2016-01-01').primaryEndpoints.queue]",
                     "storageAccountName": "[parameters('supportLogStorageAccountName')]",
-                    "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.table]"
+                    "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), '2016-01-01').primaryEndpoints.table]"
                 },
                 "managementEndpoint": "[concat('http://',reference(concat(parameters('lbIPName'),'-','0')).dnsSettings.fqdn,':',parameters('nt0fabricHttpGatewayPort'))]",
                 "nodeTypes": [

--- a/Windows/parameters.json
+++ b/Windows/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "clusterName": {
-            "value": "sfdatadogwindows"
+            "value": "sfdatadog"
         },
         "clusterLocation": {
             "value": "eastus"
@@ -24,7 +24,7 @@
             "value": "sfdatadogwindows-PubIP"
         },
         "dnsName": {
-            "value": "sfdatadogwindows"
+            "value": "sfdatadog"
         },
         "virtualNetworkName": {
             "value": "VNet-sfdatadogwindows"
@@ -36,10 +36,10 @@
             "value": "LBIP-sfdatadogwindows"
         },
         "applicationDiagnosticsStorageAccountName": {
-            "value": "sfdgsfdatadogwindows3365"
+            "value": "sfdgsfdatadog3365"
         },
         "supportLogStorageAccountName": {
-            "value": "sflogssfdatadogwindows7871"
+            "value": "sflogssfdatadog7871"
         },
         "vmImageSku": {
             "value": "2016-Datacenter-with-Containers"

--- a/Windows/parameters.json
+++ b/Windows/parameters.json
@@ -20,17 +20,11 @@
         "nicName": {
             "value": "NIC-sfdatadogwindows"
         },
-        "publicIPAddressName": {
-            "value": "sfdatadogwindows-PubIP"
-        },
         "dnsName": {
             "value": "sfdatadog"
         },
         "virtualNetworkName": {
             "value": "VNet-sfdatadogwindows"
-        },
-        "lbName": {
-            "value": "LB-sfdatadogwindows"
         },
         "lbIPName": {
             "value": "LBIP-sfdatadogwindows"
@@ -67,6 +61,9 @@
         },
         "datadog_api_key": {
             "value": ""
+        },
+        "datadog_site": {
+            "value": "datadoghq.com"
         }
     }
 }

--- a/Windows/parameters.json
+++ b/Windows/parameters.json
@@ -11,12 +11,6 @@
         "computeLocation": {
             "value": "eastus"
         },
-        "adminUserName": {
-            "value": "dekapur"
-        },
-        "adminPassword": {
-            "value": null
-        },
         "nicName": {
             "value": "NIC-sfdatadogwindows"
         },
@@ -59,8 +53,14 @@
         "nt0reverseProxyEndpointPort": {
             "value": 19081
         },
+        "adminUserName": {
+            "value": "admin"
+        },
+        "adminPassword": {
+            "value": null
+        },
         "datadog_api_key": {
-            "value": ""
+            "value": null
         },
         "datadog_site": {
             "value": "datadoghq.com"

--- a/Windows/template_datadog.json
+++ b/Windows/template_datadog.json
@@ -192,6 +192,9 @@
         },
         "datadog_api_key": {
             "type": "string"
+        },
+        "datadog_site": {
+            "type": "string"
         }
     },
     "variables": {
@@ -514,6 +517,9 @@
                                   "typeHandlerVersion": "0.5",
                                   "autoUpgradeMinorVersion": true,
                                   "settings": {
+                                    "site": "[parameters('datadog_site')]"
+                                  },
+                                  "protectedSettings": {
                                     "api_key": "[parameters('datadog_api_key')]"
                                   }
                                 }

--- a/Windows/template_datadog.json
+++ b/Windows/template_datadog.json
@@ -514,7 +514,7 @@
                                 "properties": {
                                   "publisher": "Datadog.Agent",
                                   "type": "DatadogWindowsAgent",
-                                  "typeHandlerVersion": "0.5",
+                                  "typeHandlerVersion": "1.0",
                                   "autoUpgradeMinorVersion": true,
                                   "settings": {
                                     "site": "[parameters('datadog_site')]"

--- a/Windows/template_datadog.json
+++ b/Windows/template_datadog.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "clusterLocation": {
@@ -54,21 +54,6 @@
         "computeLocation": {
             "type": "string"
         },
-        "publicIPAddressName": {
-            "type": "string",
-            "defaultValue": "PublicIP-VM"
-        },
-        "publicIPAddressType": {
-            "type": "string",
-            "allowedValues": [
-                "Dynamic"
-            ],
-            "defaultValue": "Dynamic"
-        },
-        "vmStorageAccountContainerName": {
-            "type": "string",
-            "defaultValue": "vhds"
-        },
         "adminUserName": {
             "type": "string",
             "defaultValue": "testadm",
@@ -96,10 +81,6 @@
         "nicName": {
             "type": "string",
             "defaultValue": "NIC"
-        },
-        "lbName": {
-            "type": "string",
-            "defaultValue": "LoadBalancer"
         },
         "lbIPName": {
             "type": "string",
@@ -214,11 +195,6 @@
         }
     },
     "variables": {
-        "vmssApiVersion": "2017-03-30",
-        "lbApiVersion": "2015-06-15",
-        "vNetApiVersion": "2015-06-15",
-        "storageApiVersion": "2016-01-01",
-        "publicIPApiVersion": "2015-06-15",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnet0Ref": "[concat(variables('vnetID'),'/subnets/',parameters('subnet0Name'))]",
         "lbID0": "[resourceId('Microsoft.Network/loadBalancers', concat('LB','-', parameters('clusterName'),'-',parameters('vmNodeType0Name')))]",
@@ -226,16 +202,14 @@
         "lbPoolID0": "[concat(variables('lbID0'),'/backendAddressPools/LoadBalancerBEAddressPool')]",
         "lbProbeID0": "[concat(variables('lbID0'),'/probes/FabricGatewayProbe')]",
         "lbHttpProbeID0": "[concat(variables('lbID0'),'/probes/FabricHttpGatewayProbe')]",
-        "lbNatPoolID0": "[concat(variables('lbID0'),'/inboundNatPools/LoadBalancerBEAddressNatPool')]",
-        "vmStorageAccountName0": "[toLower(concat(uniqueString(resourceGroup().id), '1', '0' ))]"
+        "lbNatPoolID0": "[concat(variables('lbID0'),'/inboundNatPools/LoadBalancerBEAddressNatPool')]"
     },
     "resources": [
         {
-            "apiVersion": "[variables('storageApiVersion')]",
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('supportLogStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {},
             "kind": "Storage",
             "sku": {
@@ -247,11 +221,10 @@
             }
         },
         {
-            "apiVersion": "[variables('storageApiVersion')]",
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[parameters('applicationDiagnosticsStorageAccountName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {},
             "kind": "Storage",
             "sku": {
@@ -263,11 +236,10 @@
             }
         },
         {
-            "apiVersion": "[variables('vNetApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtualNetworkName')]",
             "location": "[parameters('computeLocation')]",
-            "dependsOn": [],
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -289,7 +261,7 @@
             }
         },
         {
-            "apiVersion": "[variables('publicIPApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[concat(parameters('lbIPName'),'-','0')]",
             "location": "[parameters('computeLocation')]",
@@ -305,7 +277,7 @@
             }
         },
         {
-            "apiVersion": "[variables('lbApiVersion')]",
+            "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/loadBalancers",
             "name": "[concat('LB','-', parameters('clusterName'),'-',parameters('vmNodeType0Name'))]",
             "location": "[parameters('computeLocation')]",
@@ -494,7 +466,7 @@
             }
         },
         {
-            "apiVersion": "[variables('vmssApiVersion')]",
+            "apiVersion": "2017-03-30",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "name": "[parameters('vmNodeType0Name')]",
             "location": "[parameters('computeLocation')]",
@@ -675,17 +647,14 @@
                 "addonFeatures": [
                     "DnsService"
                 ],
-                "clientCertificateCommonNames": [],
-                "clientCertificateThumbprints": [],
                 "clusterState": "Default",
                 "diagnosticsStorageAccountConfig": {
-                    "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",
+                    "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), '2016-01-01').primaryEndpoints.blob]",
                     "protectedAccountKeyName": "StorageAccountKey1",
-                    "queueEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.queue]",
+                    "queueEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')),'2016-01-01').primaryEndpoints.queue]",
                     "storageAccountName": "[parameters('supportLogStorageAccountName')]",
-                    "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.table]"
+                    "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('supportLogStorageAccountName')), '2016-01-01').primaryEndpoints.table]"
                 },
-                "fabricSettings": [],
                 "managementEndpoint": "[concat('http://',reference(concat(parameters('lbIPName'),'-','0')).dnsSettings.fqdn,':',parameters('nt0fabricHttpGatewayPort'))]",
                 "nodeTypes": [
                     {

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,18 @@ These ARM templates set up an insecure Service Fabric cluster that includes the 
 
 ## Usage
 
-Use the [Azure PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) to 
+There are two templates, for both Windows and Linux.
+First, select the template you want to use and fill in the parameters, including Datadog's API key, Datadog's site and the administrator password for each node's administrator account.
+
+After that, use the [Azure PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) to 
 
 1. [create a resource group](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azresourcegroup) and 
 2. [deploy this repository's template](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azresourcegroupdeployment).
 
-There are two templates, for both Windows and Linux.
+Assuming the relevant variables are set an example command sequence for the deployment could be:
+
+``` powershell
+Login-AzAccount
+New-AzResourceGroup -Name $ResourceGroup -Location "eastus"
+New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroup -TemplateFile $TemplateFile -TemplateParameterFile $ParametersFile -Verbose
+```

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,12 @@
-# Service Fabric Cluster with Datadog installed as a VM extension on each node
+# Datadog Service Fabric Cluster Template
 
-These ARM templates set up unsecure Service Fabric clusters that include the Datadog agent on each node as a VM extension.
+These ARM templates set up an insecure Service Fabric cluster that includes the Datadog Agent on each node as a VM extension.
 
-## PowerShell commands to run:
+## Usage
 
-```powershell
-Login-AzureRmAccount
+Use the [Azure PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) to 
 
-Select-AzureRmSubscription -SubscriptionId <SubscriptionId>
+1. [create a resource group](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azresourcegroup) and 
+2. [deploy this repository's template](https://docs.microsoft.com/en-us/powershell/module/az.resources/new-azresourcegroupdeployment).
 
-$ResouceGroup = <resourceGroupName>
-
-New-AzureRmResourceGroup -Name $ResouceGroup -Location "eastus"
-
-New-AzureRmResourceGroupDeployment -ResourceGroupName $ResouceGroup -TemplateFile '<Path to template_datadog.json>' -TemplateParameterFile '<Path to parameters.json>' -Verbose
-```
+There are two templates, for both Windows and Linux.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ These ARM templates set up an insecure Service Fabric cluster that includes the 
 
 ## Usage
 
-There are two templates, for both Windows and Linux.
+There are two templates: one that sets up a Windows cluster and another one that sets up a Linux cluster.
 First, select the template you want to use and fill in the parameters, including Datadog's API key, Datadog's site and the administrator password for each node's administrator account.
 
 After that, use the [Azure PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) to 


### PR DESCRIPTION
### What does this PR do?

- Fix Datadog Azure Service Fabric templates to work with the most recent version of the extension
- Update documentation
- Set CODEOWNERS

### Additional notes

- [Rendered docs](https://github.com/DataDog/service-fabric-datadog/blob/mx-psi/fix-templates/readme.md)
- [Rendered CONTRIBUTING.md](https://github.com/DataDog/service-fabric-datadog/blob/mx-psi/fix-templates/CONTRIBUTING.md)

### How to test this

- Follow the instructions on the `README.md` file on Windows and Linux. Log into a sample node and check that the Agent is running with the correct `site` and `api_key`.

**Note:** Pending some changes on the Linux version of the extension it can only be tested for Windows as of now.