### PR TITLE
Set API key as a secure string

### DIFF
--- a/Linux/template_datadog.json
+++ b/Linux/template_datadog.json
@@ -191,7 +191,7 @@
             "defaultValue": "Standard_D1_v2"
         },
         "datadog_api_key": {
-            "type": "string"
+            "type": "securestring"
         },
         "datadog_site": {
             "type": "string"

--- a/Windows/template_datadog.json
+++ b/Windows/template_datadog.json
@@ -191,7 +191,7 @@
             "defaultValue": "Standard_D1_v2"
         },
         "datadog_api_key": {
-            "type": "string"
+            "type": "securestring"
         },
         "datadog_site": {
             "type": "string"


### PR DESCRIPTION
This way it doesn't show up in logs

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Set API key as a secure string parameter.

### Motivation

<!-- What inspired you to submit this pull request? -->

- Hide it on the logs